### PR TITLE
Add missing filter condition in vulnerability findings dashboard tile

### DIFF
--- a/dashboards/security/Vulnerability findings.json
+++ b/dashboards/security/Vulnerability findings.json
@@ -1,5 +1,5 @@
 {
-  "version": 15,
+  "version": 16,
   "variables": [
     {
       "key": "Product",
@@ -1129,7 +1129,7 @@
     "17": {
       "type": "data",
       "title": "",
-      "query": "fetch events\n// data access\n| filter dt.system.bucket == \"default_security_custom_events\"\n     AND event.type == \"VULNERABILITY_FINDING_EVENT\"\n     AND isNotNull(vulnerable_component.name)\n| dedup {affected_entity.id, vulnerability.external_id, vulnerable_component.name}, sort: {timestamp desc}\n// dashboard variables\n| filter (in(\"All\",$Product) OR in(event.provider_product, $Product))\n     AND (in(\"All\",$RiskLevel) OR in(vulnerability.risk.level, $RiskLevel))\n     AND (in(\"All\",$Vulnerability) OR in(vulnerability.external_id, $Vulnerability))\n     AND (in(\"All\",$Component) OR in(vulnerable_component.name, $Component))\n// aggregation and custom filtering\n| summarize {\n        Critical=countIf(vulnerability.risk.level==\"CRITICAL\"),\n        High=countIf(vulnerability.risk.level==\"HIGH\"),\n        `Affected entities`=countDistinctExact(affected_entity.id),\n        `Last finding`=takeMax(timestamp)\n}, by:{Component=vulnerable_component.name}\n| sort {Critical, direction:\"descending\"}, {High, direction:\"descending\"},\n        {`Affected entities`, direction:\"descending\"}\n| limit 10",
+      "query": "fetch events\n// data access\n| filter dt.system.bucket == \"default_security_custom_events\"\n     AND event.type == \"VULNERABILITY_FINDING_EVENT\"\n     AND isNotNull(vulnerable_component.name)\n| dedup {affected_entity.id, vulnerability.external_id, vulnerable_component.name}, sort: {timestamp desc}\n// dashboard variables\n| filter (in(\"All\",$Product) OR in(event.provider_product, $Product))\n     AND (in(\"All\",$RiskLevel) OR in(vulnerability.risk.level, $RiskLevel))\n     AND (in(\"All\",$Vulnerability) OR in(vulnerability.external_id, $Vulnerability))\n     AND (in(\"All\",$Component) OR in(vulnerable_component.name, $Component))\n     AND (in(\"All\",$AffectedEntityType) OR in(affected_entity.type, $AffectedEntityType))\n// aggregation and custom filtering\n| summarize {\n        Critical=countIf(vulnerability.risk.level==\"CRITICAL\"),\n        High=countIf(vulnerability.risk.level==\"HIGH\"),\n        `Affected entities`=countDistinctExact(affected_entity.id),\n        `Last finding`=takeMax(timestamp)\n}, by:{Component=vulnerable_component.name}\n| sort {Critical, direction:\"descending\"}, {High, direction:\"descending\"},\n        {`Affected entities`, direction:\"descending\"}\n| limit 10",
       "davis": {
         "enabled": false,
         "davisVisualization": {
@@ -1186,7 +1186,8 @@
             "categoryAxisLabel": "Component",
             "valueAxisLabel": "Critical",
             "categoryAxis": "Component",
-            "valueAxis": "Critical"
+            "valueAxis": "Critical",
+            "tooltipVariant": "single"
           },
           "fieldMapping": {
             "timestamp": "Last finding",
@@ -1197,7 +1198,8 @@
               "Component"
             ]
           },
-          "hiddenLegendFields": []
+          "hiddenLegendFields": [],
+          "truncationMode": "middle"
         },
         "singleValue": {
           "showLabel": true,
@@ -1222,14 +1224,14 @@
         "honeycomb": {
           "shape": "square",
           "dataMappings": {
-            "value": "Component"
+            "value": "Critical"
           },
           "legend": "auto",
           "displayedFields": [
             "Component"
           ],
           "colorMode": "color-palette",
-          "colorPalette": "categorical"
+          "colorPalette": "blue"
         },
         "histogram": {
           "dataMappings": [


### PR DESCRIPTION
All widgets must contain filter for affected entity type.

Tile: Top 10 vulnerable components by number of critical findings didn't have it, was added.